### PR TITLE
Starting bring all potentially used micro flags into yaml

### DIFF
--- a/application.dist.yaml
+++ b/application.dist.yaml
@@ -10,3 +10,6 @@ database:
   password: password
   options: someoptions using Pear DB like options or nothing
   maxConnections: 5
+registry:
+  hostname: localhost
+  port: 8500

--- a/main.go
+++ b/main.go
@@ -13,7 +13,7 @@ import (
 var version string = "1.0.0"
 
 func main() {
-	service := config.NewService(version, initialize)
+	service := config.NewService(version, "auth-srv", initialize)
 
 	abaeve_auth.RegisterUserAuthenticationAdminHandler(service.Server(), &handler.AdminHandler{service.Client()})
 	abaeve_auth.RegisterUserAuthenticationHandler(service.Server(), &handler.AuthHandler{service.Client()})


### PR DESCRIPTION
Configuration files other than process management configuration files
are slightly more consumable by users.  Bringing in all relevant flags
from micro into our own configuration seems useful in this regard.